### PR TITLE
Close channels

### DIFF
--- a/sources/aggregate.go
+++ b/sources/aggregate.go
@@ -35,7 +35,12 @@ func (a *Aggregate) Read(ctx context.Context) (<-chan File, <-chan Error) {
 				select {
 				case <-ctx.Done():
 					return
-				case e := <-err:
+				case e, ok := <-err:
+					if !ok {
+						done = true
+						break
+					}
+
 					onError <- e
 				case f, ok := <-next:
 					if !ok {
@@ -47,6 +52,9 @@ func (a *Aggregate) Read(ctx context.Context) (<-chan File, <-chan Error) {
 				}
 			}
 		}
+
+		close(onNext)
+		close(onError)
 	}()
 
 	return onNext, onError


### PR DESCRIPTION
This pull request makes improvements to the `Read` method in the `Aggregate` struct within `sources/aggregate.go`. The changes enhance error handling and ensure proper channel closure to avoid potential resource leaks.

Enhancements to error handling:

* Added a check for the `ok` value when receiving from the `err` channel to handle cases where the channel is closed. If the channel is closed, the `done` flag is set to `true`, and the loop breaks. (`[sources/aggregate.goL38-R43](diffhunk://#diff-3d607b1611511cce591b537b146694de70eddef5d4cb79efcc29bc4bfbbacae3L38-R43)`)

Proper channel closure:

* Ensured that the `onNext` and `onError` channels are closed after the loop completes, preventing resource leaks and signaling the end of data transmission. (`[sources/aggregate.goR55-R57](diffhunk://#diff-3d607b1611511cce591b537b146694de70eddef5d4cb79efcc29bc4bfbbacae3R55-R57)`)