### PR TITLE
Fix/release case

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,8 @@ builds:
 
 archives:
     - name_template: >-
-        {{- .ProjectName }}_
-        {{- title tolower .Os }}_
+        tolower {{- .ProjectName }}_
+        {{- title .Os }}_
         {{- if eq .Arch "amd64" }}x86_64
         {{- else if eq .Arch "386" }}i386
         {{- else }}{{ .Arch }}{{ end }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
 archives:
     - name_template: >-
         {{- .ProjectName }}_
-        {{- title .Os }}_
+        {{- title tolower .Os }}_
         {{- if eq .Arch "amd64" }}x86_64
         {{- else if eq .Arch "386" }}i386
         {{- else }}{{ .Arch }}{{ end }}


### PR DESCRIPTION
This pull request modifies the `.goreleaser.yml` file to ensure that the `ProjectName` in archive names is always in lowercase.

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L28-R28): Updated the `name_template` in the `archives` section to apply the `tolower` function to `ProjectName`, ensuring consistency in lowercase formatting.