### PR TITLE
Update MontFerret to v2.0.0-alpha.34; add built-in HTTP policy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,19 @@ RETURN T::EQ(payload.id, "123")
 
 Mock API entries use the same binding syntax as static serving: `<path>`, `<path>:<port>`, `<path>@<alias>`, and `<path>@<alias>:<port>`. `--serve-bind` and `--serve-host` also apply to mock API servers.
 
+### 🔒 Built-in Filesystem Policy
+
+The built-in runtime exposes FQL filesystem functions through a sandbox rooted at Lab's current working directory. Use `--policy-fs-root` to select a narrower relative or absolute root, and add `--policy-fs-read-only` to permit reads while rejecting writes, directory changes, and removals.
+
+```bash
+lab run \
+  --policy-fs-root=./fixtures \
+  --policy-fs-read-only \
+  tests/
+```
+
+The equivalent environment variables are `LAB_POLICY_FS_ROOT` and `LAB_POLICY_FS_READ_ONLY`.
+
 ### 🔄 Remote Ferret Runtime
 
 Lab can execute tests against remote Ferret instances instead of using the built-in runtime.
@@ -684,7 +697,7 @@ lab run \
 
 When the runtime URL already includes a path, Lab sends `run` requests to that exact path. The optional `runtime-param=path` value overrides the run endpoint only. `lab version --runtime=...` uses the runtime URL path and requests its sibling `/info` endpoint.
 
-The `--policy-http-*` flags configure only Lab's built-in Ferret runtime. Lab rejects them when `--runtime` selects an HTTP or binary adapter because policy enforcement belongs to that external runtime.
+The `--policy-fs-*` and `--policy-http-*` flags configure only Lab's built-in Ferret runtime. Lab rejects them when `--runtime` selects an HTTP or binary adapter because policy enforcement belongs to that external runtime.
 
 The HTTP runtime sends POST requests with:
 
@@ -795,6 +808,8 @@ These flags apply to `lab run`.
 | `--wait` | `-w` | `LAB_WAIT` | - | Wait for resource availability |
 | `--wait-timeout` | `--wt` | `LAB_WAIT_TIMEOUT` | `5` | Wait timeout in seconds |
 | `--wait-attempts` | - | `LAB_WAIT_ATTEMPTS` | `5` | Number of wait attempts |
+| `--policy-fs-root` | - | `LAB_POLICY_FS_ROOT` | Current working directory | Filesystem root for the built-in runtime |
+| `--policy-fs-read-only` | - | `LAB_POLICY_FS_READ_ONLY` | `false` | Make the built-in runtime filesystem read-only |
 | `--policy-http-allowed-schemes` | - | `LAB_POLICY_HTTP_ALLOWED_SCHEMES` | `http,https` | Allowed outbound HTTP URL schemes |
 | `--policy-http-allowed-methods` | - | `LAB_POLICY_HTTP_ALLOWED_METHODS` | `GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS` | Allowed outbound HTTP methods |
 | `--policy-http-allowed-hosts` | - | `LAB_POLICY_HTTP_ALLOWED_HOSTS` | - | Allowed exact hosts or `host:port` values |

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ LET doc = DOCUMENT(@lab.static.website, { driver: "cdp" })
 #### Multiple Static Endpoints
 
 ```bash
-lab run --serve ./app --serve ./api-mocks tests/
+lab run --policy-http-allow-localhost --serve ./app --serve ./api-mocks tests/
 ```
 
 FQL script:
@@ -577,7 +577,7 @@ LET apiData = IO::NET::HTTP::GET(@lab.static["api-mocks"] + "/users.json")
 #### Custom Static Aliases
 
 ```bash
-lab run --serve ./frontend@app --serve ./mockdata@api tests/
+lab run --policy-http-allow-localhost --serve ./frontend@app --serve ./mockdata@api tests/
 ```
 
 FQL script:
@@ -591,6 +591,7 @@ LET userData = IO::NET::HTTP::GET(@lab.static.api + "/user/123.json")
 
 ```bash
 lab run \
+  --policy-http-allow-localhost \
   --serve ./dist@webapp \
   --serve ./test-fixtures@fixtures \
   --serve ./mock-apis@mocks \
@@ -637,8 +638,10 @@ paths:
 Run tests with the mock API:
 
 ```bash
-lab run --mock ./users.yaml@api tests/
+lab run --policy-http-allow-localhost --mock ./users.yaml@api tests/
 ```
+
+Ferret's built-in HTTP client blocks localhost by default. Tests that access `@lab.static` or `@lab.mock` through `IO::NET::HTTP` must opt in with `--policy-http-allow-localhost` (or `LAB_POLICY_HTTP_ALLOW_LOCALHOST=true`). Starting a local service does not broaden the HTTP policy automatically.
 
 Serve the mock API without running tests:
 
@@ -680,6 +683,8 @@ lab run \
 ```
 
 When the runtime URL already includes a path, Lab sends `run` requests to that exact path. The optional `runtime-param=path` value overrides the run endpoint only. `lab version --runtime=...` uses the runtime URL path and requests its sibling `/info` endpoint.
+
+The `--policy-http-*` flags configure only Lab's built-in Ferret runtime. Lab rejects them when `--runtime` selects an HTTP or binary adapter because policy enforcement belongs to that external runtime.
 
 The HTTP runtime sends POST requests with:
 
@@ -790,6 +795,24 @@ These flags apply to `lab run`.
 | `--wait` | `-w` | `LAB_WAIT` | - | Wait for resource availability |
 | `--wait-timeout` | `--wt` | `LAB_WAIT_TIMEOUT` | `5` | Wait timeout in seconds |
 | `--wait-attempts` | - | `LAB_WAIT_ATTEMPTS` | `5` | Number of wait attempts |
+| `--policy-http-allowed-schemes` | - | `LAB_POLICY_HTTP_ALLOWED_SCHEMES` | `http,https` | Allowed outbound HTTP URL schemes |
+| `--policy-http-allowed-methods` | - | `LAB_POLICY_HTTP_ALLOWED_METHODS` | `GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS` | Allowed outbound HTTP methods |
+| `--policy-http-allowed-hosts` | - | `LAB_POLICY_HTTP_ALLOWED_HOSTS` | - | Allowed exact hosts or `host:port` values |
+| `--policy-http-blocked-hosts` | - | `LAB_POLICY_HTTP_BLOCKED_HOSTS` | - | Blocked exact hosts or `host:port` values |
+| `--policy-http-allow-localhost` | - | `LAB_POLICY_HTTP_ALLOW_LOCALHOST` | `false` | Allow localhost and loopback addresses |
+| `--policy-http-allow-private-networks` | - | `LAB_POLICY_HTTP_ALLOW_PRIVATE_NETWORKS` | `false` | Allow private network addresses |
+| `--policy-http-allow-link-local` | - | `LAB_POLICY_HTTP_ALLOW_LINK_LOCAL` | `false` | Allow link-local addresses |
+| `--policy-http-default-headers` | - | `LAB_POLICY_HTTP_DEFAULT_HEADERS` | - | Default request headers as a JSON string map |
+| `--policy-http-blocked-request-headers` | - | `LAB_POLICY_HTTP_BLOCKED_REQUEST_HEADERS` | - | Blocked request header names |
+| `--policy-http-timeout` | - | `LAB_POLICY_HTTP_TIMEOUT` | `30s` | Overall HTTP timeout |
+| `--policy-http-no-timeout` | - | `LAB_POLICY_HTTP_NO_TIMEOUT` | `false` | Explicitly disable the overall HTTP timeout |
+| `--policy-http-max-request-size` | - | `LAB_POLICY_HTTP_MAX_REQUEST_SIZE` | `16777216` | Maximum request body size in bytes |
+| `--policy-http-unlimited-request-size` | - | `LAB_POLICY_HTTP_UNLIMITED_REQUEST_SIZE` | `false` | Explicitly disable the request body limit |
+| `--policy-http-max-response-size` | - | `LAB_POLICY_HTTP_MAX_RESPONSE_SIZE` | `16777216` | Maximum response body size in bytes |
+| `--policy-http-unlimited-response-size` | - | `LAB_POLICY_HTTP_UNLIMITED_RESPONSE_SIZE` | `false` | Explicitly disable the response body limit |
+| `--policy-http-max-response-header-size` | - | `LAB_POLICY_HTTP_MAX_RESPONSE_HEADER_SIZE` | `1048576` | Maximum response header size in bytes |
+| `--policy-http-follow-redirects` | - | `LAB_POLICY_HTTP_FOLLOW_REDIRECTS` | `true` | Follow HTTP redirects |
+| `--policy-http-max-redirects` | - | `LAB_POLICY_HTTP_MAX_REDIRECTS` | `10` | Maximum redirects to follow |
 
 These flags apply to `lab serve`.
 

--- a/cmd/fs_policy.go
+++ b/cmd/fs_policy.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/MontFerret/lab/v2/pkg/runtime"
+)
+
+func fsPolicyFlags(hidden bool) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "policy-fs-root",
+			Usage:   "filesystem root directory for the built-in runtime",
+			Sources: cli.EnvVars("LAB_POLICY_FS_ROOT"),
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-fs-read-only",
+			Usage:   "make the built-in runtime filesystem read-only",
+			Sources: cli.EnvVars("LAB_POLICY_FS_READ_ONLY"),
+			Hidden:  hidden,
+		},
+	}
+}
+
+func fsPolicyFromCommand(cmd *cli.Command) (*runtime.FileSystemPolicy, error) {
+	if cmd == nil {
+		return nil, nil
+	}
+
+	rootSet := cmd.IsSet("policy-fs-root")
+	readOnlySet := cmd.IsSet("policy-fs-read-only")
+	if !rootSet && !readOnlySet {
+		return nil, nil
+	}
+
+	policy := &runtime.FileSystemPolicy{
+		ReadOnly: cmd.Bool("policy-fs-read-only"),
+	}
+
+	if rootSet {
+		policy.Root = strings.TrimSpace(cmd.String("policy-fs-root"))
+		if policy.Root == "" {
+			return nil, fmt.Errorf("--policy-fs-root cannot be empty")
+		}
+	}
+
+	return policy, nil
+}

--- a/cmd/fs_policy_test.go
+++ b/cmd/fs_policy_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/MontFerret/lab/v2/pkg/runtime"
+)
+
+func TestFSPolicyFlags(t *testing.T) {
+	policy, err := runFSPolicyCommand(t, "--policy-fs-root= ./fixtures ", "--policy-fs-read-only")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if policy == nil {
+		t.Fatal("expected filesystem policy")
+	}
+
+	if policy.Root != "./fixtures" {
+		t.Fatalf("expected trimmed root, got %q", policy.Root)
+	}
+
+	if !policy.ReadOnly {
+		t.Fatal("expected read-only policy")
+	}
+}
+
+func TestFSPolicyFlagsRemainUnsetByDefault(t *testing.T) {
+	policy, err := runFSPolicyCommand(t)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if policy != nil {
+		t.Fatalf("expected no filesystem policy, got %#v", policy)
+	}
+}
+
+func TestFSPolicyFlagsRejectExplicitBlankRoot(t *testing.T) {
+	_, err := runFSPolicyCommand(t, "--policy-fs-root= \t ")
+	if err == nil || err.Error() != "--policy-fs-root cannot be empty" {
+		t.Fatalf("expected blank root error, got %v", err)
+	}
+}
+
+func runFSPolicyCommand(t *testing.T, args ...string) (*runtime.FileSystemPolicy, error) {
+	t.Helper()
+
+	var policy *runtime.FileSystemPolicy
+	command := &cli.Command{
+		Name:  "run",
+		Flags: fsPolicyFlags(false),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			var err error
+			policy, err = fsPolicyFromCommand(cmd)
+
+			return err
+		},
+	}
+
+	err := command.Run(context.Background(), append([]string{"run"}, args...))
+
+	return policy, err
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -114,6 +114,11 @@ func staticServerSettingsFromCommand(cmd *cli.Command) staticserver.Settings {
 }
 
 func newRuntime(cmd *cli.Command, params map[string]interface{}) (runtime.Runtime, error) {
+	fsPolicy, err := fsPolicyFromCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
 	httpPolicy, err := httpPolicyOptionsFromCommand(cmd)
 	if err != nil {
 		return nil, err
@@ -122,6 +127,7 @@ func newRuntime(cmd *cli.Command, params map[string]interface{}) (runtime.Runtim
 	rt, err := runtime.New(runtime.Options{
 		Type:       cmd.String("runtime"),
 		Params:     params,
+		FSPolicy:   fsPolicy,
 		HTTPPolicy: httpPolicy,
 	})
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -114,9 +114,15 @@ func staticServerSettingsFromCommand(cmd *cli.Command) staticserver.Settings {
 }
 
 func newRuntime(cmd *cli.Command, params map[string]interface{}) (runtime.Runtime, error) {
+	httpPolicy, err := httpPolicyOptionsFromCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
 	rt, err := runtime.New(runtime.Options{
-		Type:   cmd.String("runtime"),
-		Params: params,
+		Type:       cmd.String("runtime"),
+		Params:     params,
+		HTTPPolicy: httpPolicy,
 	})
 
 	if err != nil {

--- a/cmd/http_policy.go
+++ b/cmd/http_policy.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v3"
+
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+)
+
+const (
+	defaultHTTPPolicyTimeout               = 30 * time.Second
+	defaultHTTPPolicyMaxRequestSize  int64 = 16 << 20
+	defaultHTTPPolicyMaxResponseSize int64 = 16 << 20
+	defaultHTTPPolicyMaxHeaderSize   int64 = 1 << 20
+	defaultHTTPPolicyMaxRedirects          = 10
+)
+
+func httpPolicyFlags(hidden bool) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:    "policy-http-allowed-schemes",
+			Usage:   "allowed outbound HTTP URL schemes",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_ALLOWED_SCHEMES"),
+			Value:   []string{"http", "https"},
+			Hidden:  hidden,
+		},
+		&cli.StringSliceFlag{
+			Name:    "policy-http-allowed-methods",
+			Usage:   "allowed outbound HTTP methods",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_ALLOWED_METHODS"),
+			Value:   []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+			Hidden:  hidden,
+		},
+		&cli.StringSliceFlag{
+			Name:    "policy-http-allowed-hosts",
+			Usage:   "allowed outbound HTTP hosts (exact host or host:port)",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_ALLOWED_HOSTS"),
+			Hidden:  hidden,
+		},
+		&cli.StringSliceFlag{
+			Name:    "policy-http-blocked-hosts",
+			Usage:   "blocked outbound HTTP hosts (exact host or host:port)",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_BLOCKED_HOSTS"),
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-allow-localhost",
+			Usage:   "allow outbound HTTP access to localhost and loopback addresses",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_ALLOW_LOCALHOST"),
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-allow-private-networks",
+			Usage:   "allow outbound HTTP access to private network addresses",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_ALLOW_PRIVATE_NETWORKS"),
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-allow-link-local",
+			Usage:   "allow outbound HTTP access to link-local addresses",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_ALLOW_LINK_LOCAL"),
+			Hidden:  hidden,
+		},
+		&cli.StringFlag{
+			Name:    "policy-http-default-headers",
+			Usage:   "default outbound HTTP headers as a JSON object",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_DEFAULT_HEADERS"),
+			Hidden:  hidden,
+		},
+		&cli.StringSliceFlag{
+			Name:    "policy-http-blocked-request-headers",
+			Usage:   "blocked outbound HTTP request header names",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_BLOCKED_REQUEST_HEADERS"),
+			Hidden:  hidden,
+		},
+		&cli.DurationFlag{
+			Name:    "policy-http-timeout",
+			Usage:   "overall outbound HTTP timeout",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_TIMEOUT"),
+			Value:   defaultHTTPPolicyTimeout,
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-no-timeout",
+			Usage:   "disable the overall outbound HTTP timeout",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_NO_TIMEOUT"),
+			Hidden:  hidden,
+		},
+		&cli.Int64Flag{
+			Name:    "policy-http-max-request-size",
+			Usage:   "maximum outbound HTTP request body size in bytes",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_MAX_REQUEST_SIZE"),
+			Value:   defaultHTTPPolicyMaxRequestSize,
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-unlimited-request-size",
+			Usage:   "disable the outbound HTTP request body size limit",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_UNLIMITED_REQUEST_SIZE"),
+			Hidden:  hidden,
+		},
+		&cli.Int64Flag{
+			Name:    "policy-http-max-response-size",
+			Usage:   "maximum outbound HTTP response body size in bytes",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_MAX_RESPONSE_SIZE"),
+			Value:   defaultHTTPPolicyMaxResponseSize,
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-unlimited-response-size",
+			Usage:   "disable the outbound HTTP response body size limit",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_UNLIMITED_RESPONSE_SIZE"),
+			Hidden:  hidden,
+		},
+		&cli.Int64Flag{
+			Name:    "policy-http-max-response-header-size",
+			Usage:   "maximum outbound HTTP response header size in bytes",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_MAX_RESPONSE_HEADER_SIZE"),
+			Value:   defaultHTTPPolicyMaxHeaderSize,
+			Hidden:  hidden,
+		},
+		&cli.BoolFlag{
+			Name:    "policy-http-follow-redirects",
+			Usage:   "follow outbound HTTP redirects",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_FOLLOW_REDIRECTS"),
+			Value:   true,
+			Hidden:  hidden,
+		},
+		&cli.IntFlag{
+			Name:    "policy-http-max-redirects",
+			Usage:   "maximum number of outbound HTTP redirects",
+			Sources: cli.EnvVars("LAB_POLICY_HTTP_MAX_REDIRECTS"),
+			Value:   defaultHTTPPolicyMaxRedirects,
+			Hidden:  hidden,
+		},
+	}
+}
+
+func httpPolicyOptionsFromCommand(cmd *cli.Command) ([]ferrethttp.PolicyOption, error) {
+	if cmd == nil {
+		return nil, nil
+	}
+
+	if cmd.Bool("policy-http-no-timeout") && cmd.IsSet("policy-http-timeout") {
+		return nil, fmt.Errorf("--policy-http-no-timeout cannot be combined with --policy-http-timeout")
+	}
+
+	if cmd.Bool("policy-http-unlimited-request-size") && cmd.IsSet("policy-http-max-request-size") {
+		return nil, fmt.Errorf("--policy-http-unlimited-request-size cannot be combined with --policy-http-max-request-size")
+	}
+
+	if cmd.Bool("policy-http-unlimited-response-size") && cmd.IsSet("policy-http-max-response-size") {
+		return nil, fmt.Errorf("--policy-http-unlimited-response-size cannot be combined with --policy-http-max-response-size")
+	}
+
+	var options []ferrethttp.PolicyOption
+
+	if cmd.IsSet("policy-http-allowed-schemes") {
+		options = append(options, ferrethttp.WithAllowedSchemes(cmd.StringSlice("policy-http-allowed-schemes")...))
+	}
+
+	if cmd.IsSet("policy-http-allowed-methods") {
+		options = append(options, ferrethttp.WithAllowedMethods(cmd.StringSlice("policy-http-allowed-methods")...))
+	}
+
+	if cmd.IsSet("policy-http-allowed-hosts") {
+		options = append(options, ferrethttp.WithAllowedHosts(cmd.StringSlice("policy-http-allowed-hosts")...))
+	}
+
+	if cmd.IsSet("policy-http-blocked-hosts") {
+		options = append(options, ferrethttp.WithBlockedHosts(cmd.StringSlice("policy-http-blocked-hosts")...))
+	}
+
+	if cmd.IsSet("policy-http-allow-localhost") {
+		options = append(options, ferrethttp.WithAllowLocalhost(cmd.Bool("policy-http-allow-localhost")))
+	}
+
+	if cmd.IsSet("policy-http-allow-private-networks") {
+		options = append(options, ferrethttp.WithAllowPrivateNetworks(cmd.Bool("policy-http-allow-private-networks")))
+	}
+
+	if cmd.IsSet("policy-http-allow-link-local") {
+		options = append(options, ferrethttp.WithAllowLinkLocal(cmd.Bool("policy-http-allow-link-local")))
+	}
+
+	if cmd.IsSet("policy-http-default-headers") {
+		headers := make(map[string]string)
+		if err := json.Unmarshal([]byte(cmd.String("policy-http-default-headers")), &headers); err != nil {
+			return nil, fmt.Errorf("invalid --policy-http-default-headers: expected a JSON object of string values: %w", err)
+		}
+
+		if headers == nil {
+			return nil, fmt.Errorf("invalid --policy-http-default-headers: expected a JSON object of string values")
+		}
+
+		options = append(options, ferrethttp.WithDefaultHeaders(headers))
+	}
+
+	if cmd.IsSet("policy-http-blocked-request-headers") {
+		options = append(options, ferrethttp.WithBlockedRequestHeaders(cmd.StringSlice("policy-http-blocked-request-headers")...))
+	}
+
+	if cmd.Bool("policy-http-no-timeout") {
+		options = append(options, ferrethttp.WithNoTimeout())
+	} else if cmd.IsSet("policy-http-timeout") {
+		options = append(options, ferrethttp.WithTimeout(cmd.Duration("policy-http-timeout")))
+	} else if cmd.IsSet("policy-http-no-timeout") {
+		options = append(options, ferrethttp.WithTimeout(0))
+	}
+
+	if cmd.Bool("policy-http-unlimited-request-size") {
+		options = append(options, ferrethttp.WithUnlimitedRequestSize())
+	} else if cmd.IsSet("policy-http-max-request-size") {
+		options = append(options, ferrethttp.WithMaxRequestSize(cmd.Int64("policy-http-max-request-size")))
+	} else if cmd.IsSet("policy-http-unlimited-request-size") {
+		options = append(options, ferrethttp.WithMaxRequestSize(0))
+	}
+
+	if cmd.Bool("policy-http-unlimited-response-size") {
+		options = append(options, ferrethttp.WithUnlimitedResponseSize())
+	} else if cmd.IsSet("policy-http-max-response-size") {
+		options = append(options, ferrethttp.WithMaxResponseSize(cmd.Int64("policy-http-max-response-size")))
+	} else if cmd.IsSet("policy-http-unlimited-response-size") {
+		options = append(options, ferrethttp.WithMaxResponseSize(0))
+	}
+
+	if cmd.IsSet("policy-http-max-response-header-size") {
+		options = append(options, ferrethttp.WithMaxResponseHeaderSize(cmd.Int64("policy-http-max-response-header-size")))
+	}
+
+	if cmd.IsSet("policy-http-follow-redirects") {
+		options = append(options, ferrethttp.WithFollowRedirects(cmd.Bool("policy-http-follow-redirects")))
+	}
+
+	if cmd.IsSet("policy-http-max-redirects") {
+		options = append(options, ferrethttp.WithMaxRedirects(cmd.Int("policy-http-max-redirects")))
+	}
+
+	return options, nil
+}

--- a/cmd/http_policy.go
+++ b/cmd/http_policy.go
@@ -203,28 +203,22 @@ func httpPolicyOptionsFromCommand(cmd *cli.Command) ([]ferrethttp.PolicyOption, 
 		options = append(options, ferrethttp.WithBlockedRequestHeaders(cmd.StringSlice("policy-http-blocked-request-headers")...))
 	}
 
-	if cmd.Bool("policy-http-no-timeout") {
+	if cmd.Bool("policy-http-no-timeout") || cmd.IsSet("policy-http-no-timeout") {
 		options = append(options, ferrethttp.WithNoTimeout())
 	} else if cmd.IsSet("policy-http-timeout") {
 		options = append(options, ferrethttp.WithTimeout(cmd.Duration("policy-http-timeout")))
-	} else if cmd.IsSet("policy-http-no-timeout") {
-		options = append(options, ferrethttp.WithTimeout(0))
 	}
 
-	if cmd.Bool("policy-http-unlimited-request-size") {
+	if cmd.Bool("policy-http-unlimited-request-size") || cmd.IsSet("policy-http-unlimited-request-size") {
 		options = append(options, ferrethttp.WithUnlimitedRequestSize())
 	} else if cmd.IsSet("policy-http-max-request-size") {
 		options = append(options, ferrethttp.WithMaxRequestSize(cmd.Int64("policy-http-max-request-size")))
-	} else if cmd.IsSet("policy-http-unlimited-request-size") {
-		options = append(options, ferrethttp.WithMaxRequestSize(0))
 	}
 
-	if cmd.Bool("policy-http-unlimited-response-size") {
+	if cmd.Bool("policy-http-unlimited-response-size") || cmd.IsSet("policy-http-unlimited-response-size") {
 		options = append(options, ferrethttp.WithUnlimitedResponseSize())
 	} else if cmd.IsSet("policy-http-max-response-size") {
 		options = append(options, ferrethttp.WithMaxResponseSize(cmd.Int64("policy-http-max-response-size")))
-	} else if cmd.IsSet("policy-http-unlimited-response-size") {
-		options = append(options, ferrethttp.WithMaxResponseSize(0))
 	}
 
 	if cmd.IsSet("policy-http-max-response-header-size") {

--- a/cmd/http_policy_test.go
+++ b/cmd/http_policy_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+)
+
+func TestHTTPPolicyFlagsRejectInvalidFerretPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "allowed scheme", arg: "--policy-http-allowed-schemes=not a scheme", want: "WithAllowedSchemes"},
+		{name: "allowed method", arg: "--policy-http-allowed-methods=bad method", want: "WithAllowedMethods"},
+		{name: "allowed host", arg: "--policy-http-allowed-hosts=bad host", want: "WithAllowedHosts"},
+		{name: "blocked host", arg: "--policy-http-blocked-hosts=bad host", want: "WithBlockedHosts"},
+		{name: "default header", arg: `--policy-http-default-headers={"Host":"example.test"}`, want: "WithDefaultHeaders"},
+		{name: "blocked header", arg: "--policy-http-blocked-request-headers=bad header", want: "WithBlockedRequestHeaders"},
+		{name: "timeout", arg: "--policy-http-timeout=-1s", want: "WithTimeout"},
+		{name: "request size", arg: "--policy-http-max-request-size=-1", want: "WithMaxRequestSize"},
+		{name: "response size", arg: "--policy-http-max-response-size=-1", want: "WithMaxResponseSize"},
+		{name: "response header size", arg: "--policy-http-max-response-header-size=-1", want: "WithMaxResponseHeaderSize"},
+		{name: "redirect count", arg: "--policy-http-max-redirects=-1", want: "WithMaxRedirects"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runHTTPPolicyCommand(t, tt.arg)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %s error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestHTTPPolicyFlagsRejectConflictingLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "timeout",
+			args: []string{"--policy-http-timeout=1s", "--policy-http-no-timeout"},
+			want: "--policy-http-no-timeout cannot be combined with --policy-http-timeout",
+		},
+		{
+			name: "request size",
+			args: []string{"--policy-http-max-request-size=1", "--policy-http-unlimited-request-size"},
+			want: "--policy-http-unlimited-request-size cannot be combined with --policy-http-max-request-size",
+		},
+		{
+			name: "response size",
+			args: []string{"--policy-http-max-response-size=1", "--policy-http-unlimited-response-size"},
+			want: "--policy-http-unlimited-response-size cannot be combined with --policy-http-max-response-size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runHTTPPolicyCommand(t, tt.args...)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func runHTTPPolicyCommand(t *testing.T, args ...string) error {
+	t.Helper()
+
+	command := &cli.Command{
+		Name:  "run",
+		Flags: httpPolicyFlags(false),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			options, err := httpPolicyOptionsFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := ferrethttp.New(options...)
+			if err != nil {
+				return err
+			}
+
+			if closer, ok := client.(ferrethttp.IdleConnectionCloser); ok {
+				closer.CloseIdleConnections()
+			}
+
+			return nil
+		},
+	}
+
+	return command.Run(context.Background(), append([]string{"run"}, args...))
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -148,6 +148,8 @@ func RunFlags(hidden bool) []cli.Flag {
 		},
 	}
 
+	flags = append(flags, fsPolicyFlags(hidden)...)
+
 	return append(flags, httpPolicyFlags(hidden)...)
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,7 +26,7 @@ func RunCommand() *cli.Command {
 }
 
 func RunFlags(hidden bool) []cli.Flag {
-	return []cli.Flag{
+	flags := []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:    "files",
 			Aliases: []string{"f"},
@@ -147,6 +147,8 @@ func RunFlags(hidden bool) []cli.Flag {
 			Hidden:  hidden,
 		},
 	}
+
+	return append(flags, httpPolicyFlags(hidden)...)
 }
 
 func RunAction(ctx context.Context, cmd *cli.Command) error {
@@ -163,7 +165,7 @@ func RunAction(ctx context.Context, cmd *cli.Command) error {
 	return runScripts(ctx, cmd, locations)
 }
 
-func runScripts(ctx context.Context, cmd *cli.Command, locations []string) error {
+func runScripts(ctx context.Context, cmd *cli.Command, locations []string) (runErr error) {
 	waitFor := cmd.StringSlice("wait")
 
 	if len(waitFor) > 0 {
@@ -194,6 +196,12 @@ func runScripts(ctx context.Context, cmd *cli.Command, locations []string) error
 	if err != nil {
 		return cli.Exit(err, 1)
 	}
+
+	defer func() {
+		if closeErr := rt.Close(); runErr == nil && closeErr != nil {
+			runErr = cli.Exit(closeErr, 1)
+		}
+	}()
 
 	r, err := runner.New(runner.Options{
 		Runtime:       rt,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,10 +27,15 @@ func VersionCommand(self string) *cli.Command {
 				return err
 			}
 
-			rtVersion, err := rt.Version(ctx)
+			rtVersion, versionErr := rt.Version(ctx)
+			closeErr := rt.Close()
 
-			if err != nil {
-				return err
+			if versionErr != nil {
+				return versionErr
+			}
+
+			if closeErr != nil {
+				return closeErr
 			}
 
 			fmt.Fprintln(appWriter(cmd), "Version")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/MontFerret/ferret/v2 v2.0.0-alpha.33
+	github.com/MontFerret/ferret/v2 v2.0.0-alpha.34
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-waitfor/waitfor v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/MontFerret/ferret/v2 v2.0.0-alpha.33 h1:oCxc8ip2FLLZyN5orA8aMGME8WqSuFXyzhh/nZny4Dc=
-github.com/MontFerret/ferret/v2 v2.0.0-alpha.33/go.mod h1:jkZZNJrQKhQ8K9v3lzkMKR5NnCyOUKRRKCTAwCOBq8A=
+github.com/MontFerret/ferret/v2 v2.0.0-alpha.34 h1:Yfjwq2h5IWsnvrK5T4iJ9k0FFVgheOCJBg8V/cp6Ix4=
+github.com/MontFerret/ferret/v2 v2.0.0-alpha.34/go.mod h1:jkZZNJrQKhQ8K9v3lzkMKR5NnCyOUKRRKCTAwCOBq8A=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=

--- a/main_test.go
+++ b/main_test.go
@@ -226,6 +226,30 @@ func TestRunHelpShowsExecutionFlags(t *testing.T) {
 	assertContains(t, stdout, "--serve-host string")
 	assertContains(t, stdout, "--timeout uint")
 	assertContains(t, stdout, "--runtime string")
+
+	for _, flag := range []string{
+		"--policy-http-allowed-schemes",
+		"--policy-http-allowed-methods",
+		"--policy-http-allowed-hosts",
+		"--policy-http-blocked-hosts",
+		"--policy-http-allow-localhost",
+		"--policy-http-allow-private-networks",
+		"--policy-http-allow-link-local",
+		"--policy-http-default-headers",
+		"--policy-http-blocked-request-headers",
+		"--policy-http-timeout",
+		"--policy-http-no-timeout",
+		"--policy-http-max-request-size",
+		"--policy-http-unlimited-request-size",
+		"--policy-http-max-response-size",
+		"--policy-http-unlimited-response-size",
+		"--policy-http-max-response-header-size",
+		"--policy-http-follow-redirects",
+		"--policy-http-max-redirects",
+	} {
+		assertContains(t, stdout, flag)
+	}
+
 	assertNotContains(t, stdout, "--cdn")
 	assertNotContains(t, stdout, "CDN")
 	assertEqual(t, stderr, "")
@@ -495,7 +519,7 @@ LET content = TO_STRING(IO::NET::HTTP::GET(@lab.static.app + "/hello.txt"))
 RETURN T::EQ(content, "hello")
 `)
 
-	stdout, stderr, err := runCLI(t, "run", "--serve", appDir+"@app", script)
+	stdout, stderr, err := runCLI(t, "run", "--policy-http-allow-localhost", "--serve", appDir+"@app", script)
 	if err != nil {
 		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
@@ -524,13 +548,133 @@ LET payload = JSON_PARSE(TO_STRING(IO::NET::HTTP::GET(@lab.mock.api + "/users/12
 RETURN T::EQ(payload.id, "123")
 `)
 
-	stdout, stderr, err := runCLI(t, "run", "--mock", spec+"@api", script)
+	stdout, stderr, err := runCLI(t, "run", "--policy-http-allow-localhost", "--mock", spec+"@api", script)
 	if err != nil {
 		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
 
 	assertContains(t, stdout, "Passed")
 	assertContains(t, stdout, "Done")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandHTTPPolicyBlocksLocalhostByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer srv.Close()
+
+	script := writeNamedScript(t, "blocked_localhost.fql", fmt.Sprintf(`
+RETURN TO_STRING(IO::NET::HTTP::GET(%q))
+`, srv.URL))
+
+	stdout, stderr, err := runCLI(t, "run", script)
+
+	assertErrorMessage(t, err, "has errors")
+	assertContains(t, stdout, "localhost is not allowed")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandHTTPPolicyAppliesDefaultHeaders(t *testing.T) {
+	requestHeaders := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestHeaders <- r.Header.Get("X-Lab-Policy")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	script := writeNamedScript(t, "default_headers.fql", fmt.Sprintf(`
+RETURN T::EQ(TO_STRING(IO::NET::HTTP::GET(%q)), "ok")
+`, srv.URL))
+
+	stdout, stderr, err := runCLI(
+		t,
+		"run",
+		"--policy-http-allow-localhost",
+		`--policy-http-default-headers={"X-Lab-Policy":"configured"}`,
+		script,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	select {
+	case value := <-requestHeaders:
+		assertEqual(t, value, "configured")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for HTTP policy request")
+	}
+
+	assertContains(t, stdout, "Passed")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsConflictingHTTPPolicyFlags(t *testing.T) {
+	script := writeScript(t)
+
+	stdout, stderr, err := runCLI(
+		t,
+		"run",
+		"--policy-http-timeout=1s",
+		"--policy-http-no-timeout",
+		script,
+	)
+
+	assertErrorMessage(t, err, "--policy-http-no-timeout cannot be combined with --policy-http-timeout")
+	assertEqual(t, stdout, "")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsInvalidHTTPPolicyConfiguration(t *testing.T) {
+	script := writeScript(t)
+
+	stdout, stderr, err := runCLI(t, "run", "--policy-http-allowed-hosts=bad host", script)
+
+	assertContains(t, err.Error(), "WithAllowedHosts")
+	assertContains(t, err.Error(), "bad host")
+	assertEqual(t, stdout, "")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsInvalidHTTPPolicyDefaultHeaders(t *testing.T) {
+	script := writeScript(t)
+
+	stdout, stderr, err := runCLI(t, "run", `--policy-http-default-headers={"X-Value":1}`, script)
+
+	assertContains(t, err.Error(), "invalid --policy-http-default-headers")
+	assertEqual(t, stdout, "")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsHTTPPolicyForRemoteRuntime(t *testing.T) {
+	script := writeScript(t)
+
+	stdout, stderr, err := runCLI(
+		t,
+		"run",
+		"--runtime=http://127.0.0.1:1",
+		"--policy-http-allow-localhost",
+		script,
+	)
+
+	assertErrorMessage(t, err, "HTTP policy options are only supported by the built-in runtime")
+	assertEqual(t, stdout, "")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsHTTPPolicyForBinaryRuntime(t *testing.T) {
+	script := writeScript(t)
+
+	stdout, stderr, err := runCLI(
+		t,
+		"run",
+		"--runtime=bin:/missing/ferret",
+		"--policy-http-allow-localhost",
+		script,
+	)
+
+	assertErrorMessage(t, err, "HTTP policy options are only supported by the built-in runtime")
+	assertEqual(t, stdout, "")
 	assertEqual(t, stderr, "")
 }
 
@@ -786,7 +930,8 @@ RETURN T::EQ(content, "env")
 `)
 
 	stdout, stderr, err := runCLIWithEnv(t, map[string]string{
-		"LAB_SERVE": appDir + "@app",
+		"LAB_SERVE":                       appDir + "@app",
+		"LAB_POLICY_HTTP_ALLOW_LOCALHOST": "true",
 	}, "run", script)
 	if err != nil {
 		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
@@ -817,7 +962,8 @@ RETURN T::EQ(payload.ok, true)
 `)
 
 	stdout, stderr, err := runCLIWithEnv(t, map[string]string{
-		"LAB_MOCK": spec,
+		"LAB_MOCK":                        spec,
+		"LAB_POLICY_HTTP_ALLOW_LOCALHOST": "true",
 	}, "run", script)
 	if err != nil {
 		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)

--- a/main_test.go
+++ b/main_test.go
@@ -226,6 +226,8 @@ func TestRunHelpShowsExecutionFlags(t *testing.T) {
 	assertContains(t, stdout, "--serve-host string")
 	assertContains(t, stdout, "--timeout uint")
 	assertContains(t, stdout, "--runtime string")
+	assertContains(t, stdout, "--policy-fs-root string")
+	assertContains(t, stdout, "--policy-fs-read-only")
 
 	for _, flag := range []string{
 		"--policy-http-allowed-schemes",
@@ -263,6 +265,21 @@ func TestRunCommandRejectsLegacyMockAPIFlag(t *testing.T) {
 	assertContains(t, stdout, "--mock string")
 	assertNotContains(t, stdout, "--mock-api string")
 	assertContains(t, stderr, "Incorrect Usage: flag provided but not defined: -mock-api")
+}
+
+func TestRunCommandRejectsLegacyFilesystemPolicyFlags(t *testing.T) {
+	script := writeScript(t)
+
+	for _, flag := range []string{"--fs-root", "--runtime-fs-root"} {
+		t.Run(flag, func(t *testing.T) {
+			stdout, stderr, err := runCLI(t, "run", flag+"=.", script)
+
+			assertContains(t, err.Error(), "flag provided but not defined")
+			assertContains(t, stdout, "--policy-fs-root string")
+			assertNotContains(t, stdout, flag+" string")
+			assertContains(t, stderr, "Incorrect Usage: flag provided but not defined")
+		})
+	}
 }
 
 func TestServeCommandWithoutEntriesShowsHelp(t *testing.T) {
@@ -556,6 +573,119 @@ RETURN T::EQ(payload.id, "123")
 	assertContains(t, stdout, "Passed")
 	assertContains(t, stdout, "Done")
 	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandFilesystemPolicyUsesConfiguredRoot(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "fixture.txt"), "fixture")
+	script := writeNamedScript(t, "fs_root.fql", `
+RETURN T::EQ(TO_STRING(IO::FS::READ("fixture.txt")), "fixture")
+`)
+
+	stdout, stderr, err := runCLI(t, "run", "--policy-fs-root="+root, script)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	assertContains(t, stdout, "Passed")
+	assertContains(t, stdout, "Done")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandFilesystemPolicyEnforcesReadOnly(t *testing.T) {
+	root := t.TempDir()
+	script := writeNamedScript(t, "fs_read_only.fql", `
+IO::FS::WRITE("output.txt", TO_BINARY("blocked"))
+RETURN true
+`)
+
+	stdout, stderr, err := runCLI(
+		t,
+		"run",
+		"--policy-fs-root="+root,
+		"--policy-fs-read-only",
+		script,
+	)
+
+	assertErrorMessage(t, err, "has errors")
+	assertContains(t, stdout, "filesystem is read-only")
+	assertEqual(t, stderr, "")
+
+	if _, statErr := os.Stat(filepath.Join(root, "output.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected output file not to exist, got %v", statErr)
+	}
+}
+
+func TestRunCommandFilesystemPolicySupportsEnvironment(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "fixture.txt"), "fixture")
+	script := writeNamedScript(t, "fs_policy_env.fql", `
+LET content = TO_STRING(IO::FS::READ("fixture.txt"))
+IO::FS::WRITE("output.txt", TO_BINARY(content))
+RETURN true
+`)
+
+	stdout, stderr, err := runCLIWithEnv(t, map[string]string{
+		"LAB_POLICY_FS_ROOT":      root,
+		"LAB_POLICY_FS_READ_ONLY": "true",
+	}, "run", script)
+
+	assertErrorMessage(t, err, "has errors")
+	assertContains(t, stdout, "filesystem is read-only")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandFilesystemPolicyDefaultsToWritableCurrentDirectory(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	script := writeNamedScript(t, "fs_default.fql", `
+IO::FS::WRITE("output.txt", TO_BINARY("written"))
+RETURN true
+`)
+
+	stdout, stderr, err := runCLI(t, "run", script)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "output.txt"))
+	if err != nil {
+		t.Fatalf("expected output file, got %v", err)
+	}
+
+	assertEqual(t, string(content), "written")
+	assertContains(t, stdout, "Passed")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsInvalidFilesystemPolicyRoot(t *testing.T) {
+	script := writeScript(t)
+
+	stdout, stderr, err := runCLI(t, "run", "--policy-fs-root= \t ", script)
+
+	assertErrorMessage(t, err, "--policy-fs-root cannot be empty")
+	assertEqual(t, stdout, "")
+	assertEqual(t, stderr, "")
+}
+
+func TestRunCommandRejectsFilesystemPolicyForExternalRuntime(t *testing.T) {
+	script := writeScript(t)
+
+	for _, runtimeURL := range []string{"http://127.0.0.1:1", "bin:/missing/ferret"} {
+		t.Run(runtimeURL, func(t *testing.T) {
+			stdout, stderr, err := runCLI(
+				t,
+				"run",
+				"--runtime="+runtimeURL,
+				"--policy-fs-read-only",
+				script,
+			)
+
+			assertErrorMessage(t, err, "filesystem policy options are only supported by the built-in runtime")
+			assertEqual(t, stdout, "")
+			assertEqual(t, stderr, "")
+		})
+	}
 }
 
 func TestRunCommandHTTPPolicyBlocksLocalhostByDefault(t *testing.T) {

--- a/pkg/runtime/binary.go
+++ b/pkg/runtime/binary.go
@@ -83,6 +83,10 @@ func (rt *Binary) Run(ctx context.Context, query *source.Source, params map[stri
 	return out, nil
 }
 
+func (rt *Binary) Close() error {
+	return nil
+}
+
 func (rt *Binary) paramsToArg(params map[string]any) ([]string, error) {
 	args := make([]string, 0, len(params))
 

--- a/pkg/runtime/builtin.go
+++ b/pkg/runtime/builtin.go
@@ -2,35 +2,71 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/MontFerret/ferret/v2"
+	ferretnet "github.com/MontFerret/ferret/v2/pkg/net"
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
 var version = "unknown"
 
 type Builtin struct {
-	engine *ferret.Engine
+	engine  *ferret.Engine
+	network ferretnet.Network
 }
 
-func NewBuiltin(params map[string]any) (*Builtin, error) {
+func NewBuiltin(params map[string]any, policyOptions ...ferrethttp.PolicyOption) (*Builtin, error) {
 	dir, err := os.Getwd()
 
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := ferret.New(
+	if len(policyOptions) == 0 {
+		engine, err := ferret.New(
+			ferret.WithFSRoot(dir),
+			ferret.WithParams(params),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Builtin{engine: engine}, nil
+	}
+
+	client, err := ferrethttp.New(policyOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP policy: %w", err)
+	}
+
+	network, err := ferretnet.New(ferretnet.WithHTTPClient(client))
+	if err != nil {
+		if closer, ok := client.(ferrethttp.IdleConnectionCloser); ok {
+			closer.CloseIdleConnections()
+		}
+
+		return nil, fmt.Errorf("network: %w", err)
+	}
+
+	engine, err := ferret.New(
 		ferret.WithFSRoot(dir),
 		ferret.WithParams(params),
+		ferret.WithNetwork(network),
 	)
 
 	if err != nil {
+		ferretnet.CloseIdleNetworkConnections(network)
+
 		return nil, err
 	}
 
-	return &Builtin{c}, nil
+	return &Builtin{
+		engine:  engine,
+		network: network,
+	}, nil
 }
 
 func (r *Builtin) Version(_ context.Context) (string, error) {
@@ -45,4 +81,15 @@ func (r *Builtin) Run(ctx context.Context, query *source.Source, params map[stri
 	}
 
 	return out.Content, nil
+}
+
+// Close shuts down the embedded engine and its configured HTTP network.
+func (r *Builtin) Close() error {
+	err := r.engine.Close()
+
+	if r.network != nil {
+		ferretnet.CloseIdleNetworkConnections(r.network)
+	}
+
+	return err
 }

--- a/pkg/runtime/builtin.go
+++ b/pkg/runtime/builtin.go
@@ -19,18 +19,43 @@ type Builtin struct {
 }
 
 func NewBuiltin(params map[string]any, policyOptions ...ferrethttp.PolicyOption) (*Builtin, error) {
-	dir, err := os.Getwd()
+	return newBuiltin(params, nil, policyOptions...)
+}
 
-	if err != nil {
-		return nil, err
+func newBuiltin(params map[string]any, fsPolicy *FileSystemPolicy, policyOptions ...ferrethttp.PolicyOption) (*Builtin, error) {
+	if fsPolicy == nil && len(policyOptions) == 0 {
+		return newDefaultBuiltin(params)
+	}
+
+	root := ""
+	if fsPolicy != nil {
+		root = fsPolicy.Root
+	}
+
+	if root == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	engineOptions := []ferret.Option{
+		ferret.WithFSRoot(root),
+		ferret.WithParams(params),
+	}
+
+	if fsPolicy != nil && fsPolicy.ReadOnly {
+		engineOptions = append(engineOptions, ferret.WithFSReadOnly())
 	}
 
 	if len(policyOptions) == 0 {
-		engine, err := ferret.New(
-			ferret.WithFSRoot(dir),
-			ferret.WithParams(params),
-		)
+		engine, err := ferret.New(engineOptions...)
 		if err != nil {
+			if fsPolicy != nil {
+				return nil, fmt.Errorf("filesystem policy: %w", err)
+			}
+
 			return nil, err
 		}
 
@@ -51,14 +76,14 @@ func NewBuiltin(params map[string]any, policyOptions ...ferrethttp.PolicyOption)
 		return nil, fmt.Errorf("network: %w", err)
 	}
 
-	engine, err := ferret.New(
-		ferret.WithFSRoot(dir),
-		ferret.WithParams(params),
-		ferret.WithNetwork(network),
-	)
+	engineOptions = append(engineOptions, ferret.WithNetwork(network))
+	engine, err := ferret.New(engineOptions...)
 
 	if err != nil {
 		ferretnet.CloseIdleNetworkConnections(network)
+		if fsPolicy != nil {
+			return nil, fmt.Errorf("filesystem policy: %w", err)
+		}
 
 		return nil, err
 	}
@@ -67,6 +92,23 @@ func NewBuiltin(params map[string]any, policyOptions ...ferrethttp.PolicyOption)
 		engine:  engine,
 		network: network,
 	}, nil
+}
+
+func newDefaultBuiltin(params map[string]any) (*Builtin, error) {
+	root, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	engine, err := ferret.New(
+		ferret.WithFSRoot(root),
+		ferret.WithParams(params),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Builtin{engine: engine}, nil
 }
 
 func (r *Builtin) Version(_ context.Context) (string, error) {

--- a/pkg/runtime/builtin_benchmark_test.go
+++ b/pkg/runtime/builtin_benchmark_test.go
@@ -11,7 +11,7 @@ func BenchmarkBuiltinLifecycle(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		if err := rt.engine.Close(); err != nil {
+		if err := rt.Close(); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/runtime/builtin_benchmark_test.go
+++ b/pkg/runtime/builtin_benchmark_test.go
@@ -1,0 +1,18 @@
+package runtime
+
+import "testing"
+
+func BenchmarkBuiltinLifecycle(b *testing.B) {
+	b.ReportAllocs()
+
+	for b.Loop() {
+		rt, err := NewBuiltin(nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if err := rt.engine.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/runtime/builtin_test.go
+++ b/pkg/runtime/builtin_test.go
@@ -1,0 +1,115 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
+	"github.com/MontFerret/ferret/v2/pkg/source"
+)
+
+func TestBuiltinHTTPPolicyBlocksLocalhostByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer srv.Close()
+
+	rt, err := NewBuiltin(nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	_, err = rt.Run(
+		context.Background(),
+		source.New("blocked_localhost.fql", fmt.Sprintf("RETURN IO::NET::HTTP::GET(%q)", srv.URL)),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "localhost is not allowed") {
+		t.Fatalf("expected localhost policy error, got %v", err)
+	}
+}
+
+func TestBuiltinHTTPPolicyAllowsConfiguredLocalhost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	rt, err := NewBuiltin(nil, ferrethttp.WithAllowLocalhost(true))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	_, err = rt.Run(
+		context.Background(),
+		source.New("allowed_localhost.fql", fmt.Sprintf("RETURN IO::NET::HTTP::GET(%q)", srv.URL)),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestBuiltinHTTPPolicyRejectsInvalidConfiguration(t *testing.T) {
+	_, err := NewBuiltin(nil, ferrethttp.WithAllowedHosts("bad host"))
+	if err == nil || !strings.Contains(err.Error(), "WithAllowedHosts") {
+		t.Fatalf("expected allowed-host policy error, got %v", err)
+	}
+}
+
+func TestBuiltinHTTPPolicyEnforcesResponseLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("too large"))
+	}))
+	defer srv.Close()
+
+	rt, err := NewBuiltin(
+		nil,
+		ferrethttp.WithAllowLocalhost(true),
+		ferrethttp.WithMaxResponseSize(1),
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	_, err = rt.Run(
+		context.Background(),
+		source.New("response_limit.fql", fmt.Sprintf("RETURN IO::NET::HTTP::GET(%q)", srv.URL)),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "response body exceeds") {
+		t.Fatalf("expected response-size error, got %v", err)
+	}
+}
+
+func TestBuiltinCloseSucceedsWithConfiguredNetwork(t *testing.T) {
+	rt, err := NewBuiltin(nil, ferrethttp.WithAllowLocalhost(true))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if err := rt.Close(); err != nil {
+		t.Fatalf("expected close to succeed, got %v", err)
+	}
+}
+
+func TestNewRejectsHTTPPolicyForExternalRuntimes(t *testing.T) {
+	for _, runtimeURL := range []string{"http://example.test", "bin:/usr/local/bin/ferret"} {
+		t.Run(runtimeURL, func(t *testing.T) {
+			_, err := New(Options{
+				Type:       runtimeURL,
+				HTTPPolicy: []ferrethttp.PolicyOption{ferrethttp.WithAllowLocalhost(true)},
+			})
+			if err == nil || !strings.Contains(err.Error(), "only supported by the built-in runtime") {
+				t.Fatalf("expected unsupported policy error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/runtime/builtin_test.go
+++ b/pkg/runtime/builtin_test.go
@@ -5,12 +5,75 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
+
+func TestBuiltinFilesystemPolicyUsesConfiguredRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fixture.txt"), []byte("fixture"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rt, err := New(Options{
+		FSPolicy: &FileSystemPolicy{Root: root},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	_, err = rt.Run(
+		context.Background(),
+		source.New("fs_root.fql", `RETURN TO_STRING(IO::FS::READ("fixture.txt"))`),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected configured root read to succeed, got %v", err)
+	}
+}
+
+func TestBuiltinFilesystemPolicyEnforcesReadOnly(t *testing.T) {
+	root := t.TempDir()
+	rt, err := New(Options{
+		FSPolicy: &FileSystemPolicy{Root: root, ReadOnly: true},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	_, err = rt.Run(
+		context.Background(),
+		source.New("fs_read_only.fql", `
+IO::FS::WRITE("output.txt", TO_BINARY("blocked"))
+RETURN true
+`),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "filesystem is read-only") {
+		t.Fatalf("expected read-only error, got %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(root, "output.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected output file not to exist, got %v", statErr)
+	}
+}
+
+func TestBuiltinFilesystemPolicyRejectsMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	_, err := New(Options{
+		FSPolicy: &FileSystemPolicy{Root: root},
+	})
+	if err == nil || !strings.Contains(err.Error(), "filesystem policy") || !strings.Contains(err.Error(), root) {
+		t.Fatalf("expected filesystem root error, got %v", err)
+	}
+}
 
 func TestBuiltinHTTPPolicyBlocksLocalhostByDefault(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -108,6 +171,20 @@ func TestNewRejectsHTTPPolicyForExternalRuntimes(t *testing.T) {
 				HTTPPolicy: []ferrethttp.PolicyOption{ferrethttp.WithAllowLocalhost(true)},
 			})
 			if err == nil || !strings.Contains(err.Error(), "only supported by the built-in runtime") {
+				t.Fatalf("expected unsupported policy error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestNewRejectsFilesystemPolicyForExternalRuntimes(t *testing.T) {
+	for _, runtimeURL := range []string{"http://example.test", "bin:/usr/local/bin/ferret"} {
+		t.Run(runtimeURL, func(t *testing.T) {
+			_, err := New(Options{
+				Type:     runtimeURL,
+				FSPolicy: &FileSystemPolicy{ReadOnly: true},
+			})
+			if err == nil || err.Error() != "filesystem policy options are only supported by the built-in runtime" {
 				t.Fatalf("expected unsupported policy error, got %v", err)
 			}
 		})

--- a/pkg/runtime/remote.go
+++ b/pkg/runtime/remote.go
@@ -154,6 +154,10 @@ func (rt *Remote) Run(ctx context.Context, query *source.Source, params map[stri
 	return rt.makeRequest(ctx, "POST", rt.runEndpoint(), body)
 }
 
+func (rt *Remote) Close() error {
+	return nil
+}
+
 func (rt *Remote) runEndpoint() string {
 	if rt.params.Path != "" {
 		return rt.params.Path

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2,10 +2,12 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 
+	ferrethttp "github.com/MontFerret/ferret/v2/pkg/net/http"
 	"github.com/MontFerret/ferret/v2/pkg/source"
 )
 
@@ -13,6 +15,8 @@ type (
 	Options struct {
 		Type   string
 		Params map[string]any
+		// HTTPPolicy configures outbound HTTP for the built-in runtime only.
+		HTTPPolicy []ferrethttp.PolicyOption
 	}
 
 	Func func(ctx context.Context, query *source.Source, params map[string]interface{}) ([]byte, error)
@@ -21,6 +25,9 @@ type (
 		Version(ctx context.Context) (string, error)
 
 		Run(ctx context.Context, query *source.Source, params map[string]interface{}) ([]byte, error)
+
+		// Close releases resources owned by the runtime after all runs finish.
+		Close() error
 	}
 
 	FuncStruct struct {
@@ -36,22 +43,30 @@ func New(opts Options) (Runtime, error) {
 	}
 
 	if opts.Type == "" {
-		return NewBuiltin(params)
+		return NewBuiltin(params, opts.HTTPPolicy...)
 	}
 
 	u, err := url.Parse(opts.Type)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse remote runtime url")
+		return nil, pkgerrors.Wrap(err, "failed to parse remote runtime url")
 	}
 
 	switch u.Scheme {
 	case "http", "https":
+		if len(opts.HTTPPolicy) > 0 {
+			return nil, errors.New("HTTP policy options are only supported by the built-in runtime")
+		}
+
 		return NewRemote(opts.Type, params)
 	case "bin":
+		if len(opts.HTTPPolicy) > 0 {
+			return nil, errors.New("HTTP policy options are only supported by the built-in runtime")
+		}
+
 		return NewBinary(u.Host+u.Path, params)
 	default:
-		return NewBuiltin(params)
+		return NewBuiltin(params, opts.HTTPPolicy...)
 	}
 }
 
@@ -65,4 +80,8 @@ func (f FuncStruct) Version(_ context.Context) (string, error) {
 
 func (f FuncStruct) Run(ctx context.Context, query *source.Source, params map[string]interface{}) ([]byte, error) {
 	return f.fn(ctx, query, params)
+}
+
+func (f FuncStruct) Close() error {
+	return nil
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -12,9 +12,17 @@ import (
 )
 
 type (
+	// FileSystemPolicy configures the sandboxed filesystem used by the built-in runtime.
+	FileSystemPolicy struct {
+		Root     string
+		ReadOnly bool
+	}
+
 	Options struct {
 		Type   string
 		Params map[string]any
+		// FSPolicy configures filesystem access for the built-in runtime only.
+		FSPolicy *FileSystemPolicy
 		// HTTPPolicy configures outbound HTTP for the built-in runtime only.
 		HTTPPolicy []ferrethttp.PolicyOption
 	}
@@ -43,7 +51,7 @@ func New(opts Options) (Runtime, error) {
 	}
 
 	if opts.Type == "" {
-		return NewBuiltin(params, opts.HTTPPolicy...)
+		return newBuiltin(params, opts.FSPolicy, opts.HTTPPolicy...)
 	}
 
 	u, err := url.Parse(opts.Type)
@@ -54,19 +62,27 @@ func New(opts Options) (Runtime, error) {
 
 	switch u.Scheme {
 	case "http", "https":
+		if opts.FSPolicy != nil {
+			return nil, errors.New("filesystem policy options are only supported by the built-in runtime")
+		}
+
 		if len(opts.HTTPPolicy) > 0 {
 			return nil, errors.New("HTTP policy options are only supported by the built-in runtime")
 		}
 
 		return NewRemote(opts.Type, params)
 	case "bin":
+		if opts.FSPolicy != nil {
+			return nil, errors.New("filesystem policy options are only supported by the built-in runtime")
+		}
+
 		if len(opts.HTTPPolicy) > 0 {
 			return nil, errors.New("HTTP policy options are only supported by the built-in runtime")
 		}
 
 		return NewBinary(u.Host+u.Path, params)
 	default:
-		return NewBuiltin(params, opts.HTTPPolicy...)
+		return newBuiltin(params, opts.FSPolicy, opts.HTTPPolicy...)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a comprehensive set of outbound HTTP policy controls to the CLI, allowing users to restrict or permit HTTP requests made by Ferret scripts. The changes add new command-line flags and environment variables for fine-grained HTTP policy configuration, update the documentation and tests to reflect these new controls, and ensure that the runtime enforces them consistently. Additionally, the Ferret dependency is updated to a version that supports these policies.

The most important changes are:

**HTTP Policy Feature Implementation:**
* Added a new `cmd/http_policy.go` module that defines all HTTP policy flags, parses them, and converts them into Ferret HTTP policy options, including validation for conflicting or invalid combinations (`httpPolicyFlags`, `httpPolicyOptionsFromCommand`).
* Integrated HTTP policy options into the runtime initialization by updating `newRuntime` in `cmd/helpers.go` to pass the parsed policy options, ensuring all scripts run with the specified HTTP restrictions.

**Command-Line Interface and Documentation:**
* Extended `lab run` to accept all HTTP policy flags, updated help output and documentation in `README.md` to explain the new flags, their defaults, and the need to opt in for localhost access. [[1]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L29-R29) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R150-R151) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L567-R567) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L580-R580) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R594) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L640-R645) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R687-R688) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R798-R815) [[9]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR229-R252)

**Testing and Validation:**
* Added `cmd/http_policy_test.go` to verify that invalid or conflicting flag combinations are rejected and that policy options are correctly passed to Ferret. Updated integration tests to require explicit localhost opt-in. [[1]](diffhunk://#diff-32d9cfd6a29a4f0ebb47b07f5b916f69a6d77cd8b64d3ab216f576555c8b0710R1-R101) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL498-R522)

**Dependency Update:**
* Updated Ferret to v2.0.0-alpha.34 to ensure compatibility with the new HTTP policy options.

**Resource Management Improvements:**
* Ensured that runtimes are properly closed after use in both `run` and `version` commands, handling errors gracefully. [[1]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L166-R168) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R200-R205) [[3]](diffhunk://#diff-7cb26babce207ed9c17e9dd3ead0b66d204da3cf4d11649412c197defbb3029cL30-R38)